### PR TITLE
fix linker error

### DIFF
--- a/fft/Makefile
+++ b/fft/Makefile
@@ -1,10 +1,11 @@
 CXX = g++
-CXXFLAGS = -O3 -fomit-frame-pointer -fopenmp -mavx2 -march=core-avx2 -lfftw3 -lfftw3_threads -fopenmp -Wall
+CXXFLAGS = -O3 -fomit-frame-pointer -fopenmp -mavx2 -march=core-avx2 -Wall
+LDFLAGS = -lfftw3 -lfftw3_threads
 
 all: fftw
 
 fftw: fftw.cpp
-	$(CXX) $(CXXFLAGS) $^ -o $@
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-	rm -f *.out *.o
+	rm -f *.out *.o fftw

--- a/gemm/Makefile
+++ b/gemm/Makefile
@@ -12,7 +12,7 @@ all:$(TARGET) $(OBJS)
 .SUFFIXES: .cpp
 
 $(TARGET):$(OBJS)
-	$(CXX) $(LDFLAGS) -o $@ $(OBJS)
+	$(CXX) -o $@ $(OBJS)  $(LDFLAGS)
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) -c $<


### PR DESCRIPTION
avoid link error about
```
undefined reference to `cblas_dgemm'
undefined reference to `cblas_sgemm'
undefined reference to `fftw_plan_with_nthreads'
undefined reference to `fftw_malloc'
undefined reference to `fftw_malloc'
undefined reference to `fftw_plan_dft_3d'
undefined reference to `fftw_plan_dft_3d'
undefined reference to `fftw_execute'
undefined reference to `fftw_execute'
undefined reference to `fftw_destroy_plan'
undefined reference to `fftw_destroy_plan'
undefined reference to `fftw_free'
undefined reference to `fftw_free'
```