### PR TITLE
Add fft3d test with 512^3

### DIFF
--- a/fft/fftw.cpp
+++ b/fft/fftw.cpp
@@ -52,4 +52,5 @@ void test3d(int nx, int ny, int nz) {
 int main(int argc, char **argv) {
     test3d(128, 128, 128);
     test3d(256, 256, 256);
+    test3d(512, 512, 512);
 }


### PR DESCRIPTION
256^3*sizeof(fftw_complex) bytes = 256MiB.
Is it enough small for EPYC Rome (Up to 256MiB L3 + 32MiB L2 per socket)?